### PR TITLE
check for falsy values in down-data.js

### DIFF
--- a/down-data.js
+++ b/down-data.js
@@ -22,7 +22,7 @@ var options = {
   };
   request(options, function (error, response) {
     if (error) throw new Error(error);
-    data = tsvJSON(response.body).filter(a => a.district != "");
+    data = tsvJSON(response.body).filter(a => a.district || false);
 
     transform = {
       districtSlugs: (


### PR DESCRIPTION
When running this project out of the box, an error appears as some props are empty or undefined. This comes from `latest.json`, because the `down-data` script only filters out empty strings, so some array items with other falsy values are written to the json, for e.g.:

```
"districtSlugs": [ ..., "Ampara", null ],
```
or
```
{
    "fuzzy_key": ""
}
```

I've modified a line in the `down-data.js` script to also check for falsy or empty _district_ values. It's a small change, but it will help other devs to get running much faster as I had to spend some time debugging this after forking before I could run or build the project.