### PR TITLE
Add 'key' prop to list elements

### DIFF
--- a/pages/[district].js
+++ b/pages/[district].js
@@ -149,7 +149,7 @@ export default function District(props) {
                   </a>
                 </Marker>
               ) : []}
-              {getMappable(placesList).map((a, index) => <Marker key={index} latitude={parseFloat(a.lat)} longitude={parseFloat(a.lng)}>
+              {getMappable(placesList).map(a => <Marker key={a.fuzzy_key} latitude={parseFloat(a.lat)} longitude={parseFloat(a.lng)}>
                 <Link href={`/${a.district}/${a.center}`} key={a.center}>
                 <a className={"bg-yellow-50 bg-opacity-50 rounded-full h-24 w-24 flex flex-col items-center justify-center"}>
                   <div className="h-4 w-4">
@@ -169,7 +169,7 @@ export default function District(props) {
               {t('sortDist')}
             </a>
           </div>
-          {placesList.map((itm, index) => <ItmRow key={index} onHover={onHover} itm={itm} lprefix={lprefix} />)}
+          {placesList.map(itm => <ItmRow key={itm.fuzzy_key} onHover={onHover} itm={itm} lprefix={lprefix} />)}
         </div>
       </main>
       <AppFooter />

--- a/pages/[district].js
+++ b/pages/[district].js
@@ -149,7 +149,7 @@ export default function District(props) {
                   </a>
                 </Marker>
               ) : []}
-              {getMappable(placesList).map(a => <Marker latitude={parseFloat(a.lat)} longitude={parseFloat(a.lng)}>
+              {getMappable(placesList).map((a, index) => <Marker key={index} latitude={parseFloat(a.lat)} longitude={parseFloat(a.lng)}>
                 <Link href={`/${a.district}/${a.center}`} key={a.center}>
                 <a className={"bg-yellow-50 bg-opacity-50 rounded-full h-24 w-24 flex flex-col items-center justify-center"}>
                   <div className="h-4 w-4">
@@ -169,7 +169,7 @@ export default function District(props) {
               {t('sortDist')}
             </a>
           </div>
-          {placesList.map(itm => <ItmRow onHover={onHover} itm={itm} lprefix={lprefix} />)}
+          {placesList.map((itm, index) => <ItmRow key={index} onHover={onHover} itm={itm} lprefix={lprefix} />)}
         </div>
       </main>
       <AppFooter />

--- a/pages/index.js
+++ b/pages/index.js
@@ -94,8 +94,8 @@ export default function Home(props) {
             <ChartComponent vaxData={props.vaxDataset}/>
         </div>
         <div className="md:overflow-y-auto md:overscroll-y-auto">
-          {props.districtSlugs.map(a => (
-              <Link href={`/${a}`}>
+          {props.districtSlugs.map((a, index) => (
+              <Link key={index} href={`/${a}`}>
                 <a>
                 <div className={"bg-gray-50 px-6 py-4 mb-4"}>
                   <p className={"text-xl font-medium pb-2"}>{getLocalDistrict(a)}</p>

--- a/pages/index.js
+++ b/pages/index.js
@@ -94,8 +94,8 @@ export default function Home(props) {
             <ChartComponent vaxData={props.vaxDataset}/>
         </div>
         <div className="md:overflow-y-auto md:overscroll-y-auto">
-          {props.districtSlugs.map((a, index) => (
-              <Link key={index} href={`/${a}`}>
+          {props.districtSlugs.map(a => (
+              <Link key={a} href={`/${a}`}>
                 <a>
                 <div className={"bg-gray-50 px-6 py-4 mb-4"}>
                   <p className={"text-xl font-medium pb-2"}>{getLocalDistrict(a)}</p>


### PR DESCRIPTION
Currently, elements derived from Arrays cause the following error to appear when rendering:

```
Warning: Each child in a list should have a unique "key" prop.
```

To suppress this, I've made some simple modifications in places where elements are rendered from Arrays to add key props. When elements are rendered from:

- `latest.json/dataSet`, the unique key will be the `fuzzy_key` unique attribute
- `latest.json/districtSlugs`, the unique key will be the array value itself (`"Colombo", "Gampaha"`, etc.)